### PR TITLE
Fixed negative SQL count and time

### DIFF
--- a/speedinfo/middleware.py
+++ b/speedinfo/middleware.py
@@ -83,6 +83,9 @@ class ProfilerMiddleware(object):
         self.is_active = self.can_process_request(request)
 
         if self.is_active:
+            self.initial_sql_count = 0
+            self.initial_sql_time = 0
+
             # Force DB connection to debug mode to get SQL time and number of SQL queries
             for conn in connections.all():
                 conn.force_debug_cursor = True


### PR DESCRIPTION
Counters are not initialised before adding new values which makes them go to negative values the more requests you use.

#10 